### PR TITLE
Feat: Support onKeyDown 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@coralproject/rte",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralproject/rte",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Coral Rich Text Editor",
   "author": "The Coral Project Team @coralproject",
   "license": "Apache-2.0",

--- a/src/RTE.tsx
+++ b/src/RTE.tsx
@@ -67,6 +67,8 @@ interface PropTypes {
   onFocus?: EventHandler<FocusEvent>;
   /** onFocus is called whenenver the RTE looses focus */
   onBlur?: EventHandler<FocusEvent>;
+  /** onKeyDown is called whenever a key is pressed down on the RTE */
+  onKeyDown?: KeyboardEventHandler<Element>;
   /** onKeyPress is called whenever a key is pressed on the RTE */
   onKeyPress?: KeyboardEventHandler<Element>;
 
@@ -173,6 +175,7 @@ class RTE extends React.Component<PropTypes, State> {
     this.squire.addEventListener("focus", this.handleContentEditableFocus);
     this.squire.addEventListener("blur", this.handleContentEditableBlur);
     this.squire.addEventListener("keypress", this.handleKeyPress);
+    this.squire.addEventListener("keydown", this.handleKeyDown);
 
     // Reset shortcuts. We add shortcuts through the added features.
     [
@@ -345,6 +348,14 @@ class RTE extends React.Component<PropTypes, State> {
     }
 
     this.props.onKeyPress(event);
+  };
+
+  private handleKeyDown = (event: React.KeyboardEvent<Element>) => {
+    if (!this.props.onKeyDown) {
+      return;
+    }
+
+    this.props.onKeyDown(event);
   };
 
   private renderFeatures() {


### PR DESCRIPTION
Support `onKeyDown` because `onKeyPress` doesn't fire when pressing `Enter` only.