### PR TITLE
Fix an issue that a protocol-less url is linkified as a relative URL

### DIFF
--- a/src/lib/syncLinkHrefWithContent.ts
+++ b/src/lib/syncLinkHrefWithContent.ts
@@ -7,8 +7,23 @@ const MAILTO_PROTOCOL = "mailto:";
 export default function syncLinkHrefWithContent(element: HTMLElement) {
   if (element.tagName === "A") {
     const anchorElement = element as HTMLAnchorElement;
-    const url = new URL(anchorElement.href);
-    const prefix = url.protocol === MAILTO_PROTOCOL ? MAILTO_PROTOCOL : "";
+    let url: URL | undefined,
+      prefix = "http://";
+
+    try {
+      url = new URL(anchorElement.href);
+    } catch (err) {
+      // An href may contain a url that URL doesn't accept. (e.g. "http://")
+    }
+
+    if (url) {
+      if (url.protocol === MAILTO_PROTOCOL) {
+        prefix = MAILTO_PROTOCOL;
+      } else if (anchorElement.textContent?.startsWith(url.protocol)) {
+        prefix = "";
+      }
+    }
+
     anchorElement.href = prefix + anchorElement.textContent;
     return;
   }


### PR DESCRIPTION
When a user enters `www.example.com` and hits the space key, the text
should be linkified as `<a
href="http://www.example.com">www.example.com</a>`. However the text
was linkified as `<a href="www.example.com">www.example.com</a>`.

This doesn't happen in Squire, however `syncLinkHrefWithContent` didn't
seem to take into account the case when the text content doesn't have a
protocol part.

Here's another somewhat related case.

When a user enters `http://www.example.com` and hits the space key, the
text is linkified as `<a
href="http://www.example.com">www.example.com</a>` which is good. Then
they place a cursor after `http://` and delete `://`, the href should be
updated with `href="http://httpwww.example.com"`.

However the actual behavior was that the href was updated with
`href="httpwww.example.com"`.

An expected behavior in this case may be controvertible, but generating
a relative link doesn't seem to make sense.

https://github.com/coralproject/rte/issues/15