### PR TITLE
Fix linkContentMatchHref issues

### DIFF
--- a/src/lib/syncLinkHrefWithContent.ts
+++ b/src/lib/syncLinkHrefWithContent.ts
@@ -7,8 +7,23 @@ const MAILTO_PROTOCOL = "mailto:";
 export default function syncLinkHrefWithContent(element: HTMLElement) {
   if (element.tagName === "A") {
     const anchorElement = element as HTMLAnchorElement;
-    const url = new URL(anchorElement.href);
-    const prefix = url.protocol === MAILTO_PROTOCOL ? MAILTO_PROTOCOL : "";
+    let url: URL | undefined,
+      prefix = "http://";
+
+    try {
+      url = new URL(anchorElement.href);
+    } catch (err) {
+      // An href may contain a url that URL doesn't accept. (e.g. "http://")
+    }
+
+    if (url) {
+      if (url.protocol === MAILTO_PROTOCOL) {
+        prefix = MAILTO_PROTOCOL;
+      } else if (anchorElement.textContent?.startsWith(url.protocol)) {
+        prefix = "";
+      }
+    }
+
     anchorElement.href = prefix + anchorElement.textContent;
     return;
   }

--- a/src/lib/syncLinkHrefWithContent.ts
+++ b/src/lib/syncLinkHrefWithContent.ts
@@ -11,20 +11,24 @@ export default function syncLinkHrefWithContent(element: HTMLElement): void {
     try {
       const content = anchorElement.textContent || "";
       const isEmail = EMAIL_REGEXP.test(content);
+
+      // Handle mailto case.
       if (isEmail) {
         anchorElement.href = `mailto:${content}`;
         return;
       }
 
+      // Handle rest.
       let urlContent = content;
       if (!PROTOCOL_REGEXP.test(urlContent)) {
+        // Add default protocol if none was set.
         urlContent = "http://" + content;
       }
 
       const url = new URL(urlContent);
       anchorElement.href = url.toString();
     } catch (e) {
-      // url was invalid.
+      // URL was invalid, use a `href` that does nothing.
       anchorElement.href = "javascript:;";
     }
     return;

--- a/src/lib/syncLinkHrefWithContent.ts
+++ b/src/lib/syncLinkHrefWithContent.ts
@@ -1,30 +1,32 @@
-const MAILTO_PROTOCOL = "mailto:";
+const EMAIL_REGEXP = /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i;
+const PROTOCOL_REGEXP = /^([a-zA-Z]+:\/\/)/;
 
 /**
  * Enforces contents of links to match their href.
  * @param element HTMLAnchorElement or HTMLElement potentially container anchor elements
  */
-export default function syncLinkHrefWithContent(element: HTMLElement) {
+export default function syncLinkHrefWithContent(element: HTMLElement): void {
   if (element.tagName === "A") {
     const anchorElement = element as HTMLAnchorElement;
-    let url: URL | undefined,
-      prefix = "http://";
-
     try {
-      url = new URL(anchorElement.href);
-    } catch (err) {
-      // An href may contain a url that URL doesn't accept. (e.g. "http://")
-    }
-
-    if (url) {
-      if (url.protocol === MAILTO_PROTOCOL) {
-        prefix = MAILTO_PROTOCOL;
-      } else if (anchorElement.textContent?.startsWith(url.protocol)) {
-        prefix = "";
+      const content = anchorElement.textContent || "";
+      const isEmail = EMAIL_REGEXP.test(content);
+      if (isEmail) {
+        anchorElement.href = `mailto:${content}`;
+        return;
       }
-    }
 
-    anchorElement.href = prefix + anchorElement.textContent;
+      let urlContent = content;
+      if (!PROTOCOL_REGEXP.test(urlContent)) {
+        urlContent = "http://" + content;
+      }
+
+      const url = new URL(urlContent);
+      anchorElement.href = url.toString();
+    } catch (e) {
+      // url was invalid.
+      anchorElement.href = "javascript:;";
+    }
     return;
   }
   const anchorElements = element.getElementsByTagName("a");


### PR DESCRIPTION
## What does this PR do
- Continuation of https://github.com/coralproject/rte/pull/16
- Fixes CORL-1659
- Fix protocol-less issue as described by @stanimoto

## How to test this PR
- Run `npm run dev`
- Type in e.g. `google.de` and add a space at the end.
- See that it got linkfied correctly
- See in DOM Tree that the href is set to `http://google.de`. Previously it would be just `google.de`
- Modify link text to contain illegal url characters like an `:` e.g. `go:gle.de`
- See that link href changed to `javascript:;` 