### PR TITLE
[CORL-2551]: update isActive check so buttons activate in shadow dom

### DIFF
--- a/src/RTE.tsx
+++ b/src/RTE.tsx
@@ -31,6 +31,8 @@ interface PasteEvent {
 interface PropTypes {
   /** features is an array of RTE features to be included */
   features?: ReactElement<any>[];
+  /** rteElementID is the id attached to the root RTE element */
+  rteElementID?: string;
   /** inputID is the id attached to the contenteditable field */
   inputID?: string;
   /** onChange is called whenenver the `html` value has changed */
@@ -373,6 +375,7 @@ class RTE extends React.Component<PropTypes, State> {
             ctrlKey: this.ctrlKey,
             key: b.key || i,
             ButtonComponent: this.props.ButtonComponent,
+            rteElementID: this.props.rteElementID,
             ref: this.createFeatureRefHandler(b.key || i),
           }
         );

--- a/src/factories/createToggle.tsx
+++ b/src/factories/createToggle.tsx
@@ -22,6 +22,7 @@ export interface InjectedProps {
     React.ButtonHTMLAttributes<HTMLButtonElement>
   >;
   disabled?: boolean;
+  rteElementID?: string;
 }
 
 interface State {
@@ -84,9 +85,22 @@ function createToggle<AdditionalProps>(
     private syncInProgress = false;
 
     private execCommand = () => execCommand(this.props.squire, this.props);
-    private isActive = () =>
-      document.activeElement === this.props.squire.getRoot() &&
-      isActive(this.props.squire, this.props);
+    private isActive = () => {
+      let activeElement = document.activeElement;
+      if (document.activeElement?.shadowRoot) {
+        activeElement = document.activeElement.shadowRoot.activeElement;
+      }
+      if (this.props.rteElementID) {
+        return (
+          activeElement?.getAttribute("id") === this.props.rteElementID &&
+          isActive(this.props.squire, this.props)
+        );
+      }
+      return (
+        activeElement === this.props.squire.getRoot() &&
+        isActive(this.props.squire, this.props)
+      );
+    };
     private isDisabled = () => isDisabled(this.props.squire, this.props);
 
     public constructor(


### PR DESCRIPTION
## What does this PR do?

These changes update the `isActive` check in toolbar buttons so that it correctly identifies whether a selection in the RTE has a certain type of formatting applied, and therefore if the corresponding button should be activated. We only want the buttons to show as active if the RTE is the current active element. These changes update to look inside the shadow root for the active element. In addition, because iframe encapsulation is used, we are now checking for `rteElementID`, which was added as an id on the root element to check that the RTE is activated.

Things should still work as before if there is no shadow root and no `rteElementID` to compare against.

## How do I test this PR?

Run `npm run dev`. See that the RTE still works as expected there.

With the changes in this PR (https://github.com/coralproject/talk/pull/3949), `npm link` `rte` with this branch (run `npm link path/to/rte` in `talk`) and run with `talk`. See that if you select text in the editor and bold, italicize, or apply other styles to it, the corresponding button is activated in the RTE. See that if you click to another part of the page, the button is no longer activated. If you select the text again, the button is again activated as expected.
 
## How do we deploy this PR?

This PR is related to https://github.com/coralproject/talk/pull/3949
