### PR TITLE
[CORL-2384] Switch to npm 8 and tag to v2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coralproject/rte",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coralproject/rte",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "classnames": "^2.2.6",
@@ -56,7 +56,7 @@
       },
       "engines": {
         "node": "^18.16.0",
-        "npm": "^9.5.1"
+        "npm": "^8.0.0"
       },
       "peerDependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@coralproject/rte",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Coral Rich Text Editor",
   "author": "The Coral Project Team @coralproject",
   "license": "Apache-2.0",
   "homepage": "https://github.com/coralproject/rte",
   "engines": {
     "node": "^18.16.0",
-    "npm": "^9.5.1"
+    "npm": "^8.0.0"
   },
   "files": [
     "lib",


### PR DESCRIPTION
We are doing this to match up with Coral which also uses `npm` 8.0.0.